### PR TITLE
Add links to ANGLE's samples for WebGL Insights

### DIFF
--- a/ANGLE-A-Desktop-Foundation-for-WebGL/README.md
+++ b/ANGLE-A-Desktop-Foundation-for-WebGL/README.md
@@ -1,0 +1,4 @@
+Microbenchmarks demonstrating some of the tips described in this chapter can be found among the samples in ANGLE's repository:
+
+* [TRIANGLE_FAN versus TRIANGLES performance](https://chromium.googlesource.com/angle/angle/+/master/samples/angle/tri_fan_microbench/)
+* [Texture resize versus recreation performance](https://chromium.googlesource.com/angle/angle/+/master/samples/angle/tex_redef_microbench/)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ git clone --recurse-submodules git@github.com:WebGLInsights/WebGLInsights-1.git
 * [Mozilla's Implementation of WebGL](Mozillas-Implementation-of-WebGL)
 * [Data Visualization with WebGL: from Python to JavaScript](https://github.com/vispy/webgl-insights)
 * [Getting Serious with JavaScript](Getting-Serious-with-JavaScript)
+* [ANGLE: A Desktop Foundation for WebGL](ANGLE-A-Desktop-Foundation-for-WebGL)


### PR DESCRIPTION
This adds links to the specific benchmarks within ANGLE's repository. In order to build these, one would need to clone the root ANGLE repository. If it's preferred that I link there, I can do that instead.